### PR TITLE
Added extra_packages property to package resource

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,6 +2,12 @@ driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
   chef_version: current
+  volumes:
+    # saves the apt archieves outside of the container
+    - /var/cache/apt/archives/:/var/cache/apt/archives/
+  intermediate_instructions:
+    # prevent APT from deleting the APT folder
+    - RUN rm /etc/apt/apt.conf.d/docker-clean
 
 transport:
   name: dokken
@@ -14,4 +20,8 @@ platforms:
   - name: debian-10
     driver:
       image: dokken/debian-10
+      pid_one_command: /bin/systemd
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
       pid_one_command: /bin/systemd

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -8,6 +8,7 @@ driver:
   intermediate_instructions:
     # prevent APT from deleting the APT folder
     - RUN rm /etc/apt/apt.conf.d/docker-clean
+    - RUN /usr/bin/apt-get update
 
 transport:
   name: dokken

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,6 +10,7 @@ verifier:
 
 platforms:
   - name: debian-10
+  - name: debian-11
 
 suites:
   - name: default

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -3,16 +3,17 @@
 unified_mode true
 
 property :package_name, String, default: 'gnome-core', description: 'The package name that is used to install gnome'
+property :extra_packages, Array, default: ['gnome-tweaks'], description: 'Additional packages to be installed together with the base package'
 
 action :install do
   package 'install gnome from package' do
-    package_name new_resource.package_name
+    package_name [new_resource.package_name] | new_resource.extra_packages
   end
 end
 
 action :uninstall do
   package 'uninstall gnome from package' do
-    package_name new_resource.package_name
+    package_name [new_resource.package_name] | new_resource.extra_packages
     action :remove
   end
 end

--- a/spec/unit/resources/package_spec.rb
+++ b/spec/unit/resources/package_spec.rb
@@ -15,7 +15,7 @@ describe 'codenamephp_gnome_package' do
     end
 
     it 'installs gnome-core from package' do
-      expect(chef_run).to install_package('install gnome from package').with(package_name: 'gnome-core')
+      expect(chef_run).to install_package('install gnome from package').with(package_name: %w(gnome-core gnome-tweaks))
     end
   end
 
@@ -23,6 +23,7 @@ describe 'codenamephp_gnome_package' do
     recipe do
       codenamephp_gnome_package 'install gnome' do
         package_name 'some package'
+        extra_packages ['new package', 'some package', 'another package']
       end
     end
 
@@ -31,7 +32,7 @@ describe 'codenamephp_gnome_package' do
     end
 
     it 'installs gnome-core from package' do
-      expect(chef_run).to install_package('install gnome from package').with(package_name: 'some package')
+      expect(chef_run).to install_package('install gnome from package').with(package_name: ['some package', 'new package', 'another package'])
     end
   end
 
@@ -47,14 +48,15 @@ describe 'codenamephp_gnome_package' do
     end
 
     it 'installs gnome-core from package' do
-      expect(chef_run).to remove_package('uninstall gnome from package').with(package_name: 'gnome-core')
+      expect(chef_run).to remove_package('uninstall gnome from package').with(package_name: %w(gnome-core gnome-tweaks))
     end
   end
 
-  context 'Uninstall with default attributes' do
+  context 'Uninstall with custom attributes' do
     recipe do
       codenamephp_gnome_package 'install gnome' do
         package_name 'some package'
+        extra_packages ['new package', 'some package', 'another package']
         action :uninstall
       end
     end
@@ -64,7 +66,7 @@ describe 'codenamephp_gnome_package' do
     end
 
     it 'installs gnome-core from package' do
-      expect(chef_run).to remove_package('uninstall gnome from package').with(package_name: 'some package')
+      expect(chef_run).to remove_package('uninstall gnome from package').with(package_name: ['some package', 'new package', 'another package'])
     end
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+apt_update
+
 user 'test' do
   manage_home true
   shell '/bin/bash'

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-apt_update
-
 user 'test' do
   manage_home true
   shell '/bin/bash'

--- a/test/smoke/default/package_test.rb
+++ b/test/smoke/default/package_test.rb
@@ -3,3 +3,7 @@
 describe package('gnome-core') do
   it { should be_installed }
 end
+
+describe package('gnome-tweaks') do
+  it { should be_installed }
+end


### PR DESCRIPTION
The package resource now has a new extra_packages resources that will be added to the base package name so they will be installed all together. It defaults to 'gnome-tweaks'

Fixes #3

